### PR TITLE
fixed pidfile for redhat based systems

### DIFF
--- a/manifests/vnstatd/params.pp
+++ b/manifests/vnstatd/params.pp
@@ -19,7 +19,7 @@ class vnstat::vnstatd::params inherits vnstat::params {
     'RedHat': {
       $service_name = 'vnstat'
       $log_file = '/var/log/vnstat.log'
-      $pid_file = '/run/vnstat/vnstat.pid'
+      $pid_file = '/var/run/vnstat.pid'
     }
     'Debian': {
       $service_name = 'vnstat'


### PR DESCRIPTION
- standard package uses /var/run/vnstat.pid on centos6 and redhat6
- /run does not exist, there for the service get's started on every
  puppet run

So far I could not test on redhat/centos 7 but that will come later.
