### PR TITLE
Remove path parameter from Exec.

### DIFF
--- a/manifests/createdb.pp
+++ b/manifests/createdb.pp
@@ -6,7 +6,6 @@ define vnstat::createdb ($label = undef) {
   }
 
   exec { "create-vnstat-db-${name}":
-    path => '/usr/bin:/bin',
     command => "vnstat ${args} ${name}",
     creates => "${vnstat::database_directory}/${name}",
     require => Package['vnstat'],


### PR DESCRIPTION
It's generally recommended to set a global path instead of having
to modify each and every exec to set correct paths. For example
on OpenBSD vnstat lives in /usr/local/bin.