### PR TITLE
Ensure that vnstat::createdb ends up creating the database with correct permissions

### DIFF
--- a/manifests/createdb.pp
+++ b/manifests/createdb.pp
@@ -1,4 +1,7 @@
-define vnstat::createdb ($label = undef) {
+define vnstat::createdb (
+  $user,
+  $label = undef,
+) {
 
   $args = '-u -i'
   if $label {
@@ -8,6 +11,7 @@ define vnstat::createdb ($label = undef) {
   exec { "create-vnstat-db-${name}":
     command => "vnstat ${args} ${name}",
     creates => "${vnstat::database_directory}/${name}",
+    user    => $user,
     require => Package['vnstat'],
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -27,18 +27,21 @@ class vnstat::params {
       $config = '/etc/vnstat.conf'
       $package_name   = 'vnstat'
       $database_directory = '/var/lib/vnstat'
+      $user = 'vnstat'
       $group = 'vnstat'
     }
     'Debian': {
       $config = '/etc/vnstat.conf'
       $package_name   = 'vnstat'
       $database_directory = '/var/lib/vnstat'
+      $user = 'vnstat'
       $group = 'vnstat'
     }
     'OpenBSD': {
       $config = '/etc/vnstat.conf'
       $package_name = 'vnstat'
       $database_directory = '/var/db/vnstat'
+      $user = '_vnstat'
       $group = 'wheel'
     }
     default: {


### PR DESCRIPTION
this prevents creating the databases as root, which _vnstat cannot modify.

I've tested this on OpenBSD, but I don't know about the right `$user` that should be set in `params.pp` for RH/Debian.