### PR TITLE
Adds adds namespace to createdb call

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -13,7 +13,7 @@ class vnstat::config inherits vnstat {
   # before running.  This is done by performing a
   # one-off database update for all interfaces to be
   # monitored.
-  createdb { $interfaces:
+  vnstat::createdb { $interfaces:
     user => $::vnstat::user,
   }
 }


### PR DESCRIPTION
This was broken in puppet4. Adding the qualified namespace fixed it on our end.